### PR TITLE
Fix broken link on npmjs.com/package/pta-tools

### DIFF
--- a/pta-tools/README.md
+++ b/pta-tools/README.md
@@ -4,7 +4,7 @@
 
 Plain text accounting JS helpers to interact with the ledger / hledger journal file format.
 
-On the TS / JS side Transactions are described by the [Transaction](src/types.ts) type
+On the TS / JS side Transactions are described by the [Transaction](pta-tools/src/types.ts) type
 
 ## Apis
 


### PR DESCRIPTION
Thanks for maintaining this project! <3 <3 <3
The 'Transaction' link here probably broken when you moved to Lerna:
https://www.npmjs.com/package/pta-tools
I guess this probably would fix it.